### PR TITLE
Add more `stylish time` attributes to Firefox browser window

### DIFF
--- a/stylish-firefox/content/overlay.js
+++ b/stylish-firefox/content/overlay.js
@@ -327,7 +327,8 @@ var stylishOverlay = {
 
 	addSite: function() {
 		var url = content.location.href;
-		var code = "@namespace url(http://www.w3.org/1999/xhtml);\n\n@-moz-document url(\"" + url + "\") {\n\n}";
+		var namespaceURI = content.document.documentElement.namespaceURI;
+		var code = "@namespace url(" + namespaceURI + ");\n\n@-moz-document url(\"" + url + "\") {\n\n}";
 		stylishOverlay.addCode(code);
 	},
 


### PR DESCRIPTION
For users to make themes on specified dates, e.g Christmas, ~~Valentine's Day~~, April Fools, independence day, etc.

Example

``` css
@namespace url(http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul);
[stylish-month="12"][stylish-date="25"] :-moz-any(menu, menupopup, menuitem) {
  background: green !important;
  color: red !important;
}
```
