### PR TITLE
Links opened from popup show up in unexpected ways on Opera

### DIFF
--- a/stylish-chrome/popup.html
+++ b/stylish-chrome/popup.html
@@ -48,7 +48,7 @@
 	<div id="installed"></div>
 
 	<div id="find-styles"><a id="find-styles-link" href="#"></a></div>
-	<div id="manage-styles"><a id="open-manage-link" href="manage.html" target="stylishmanage"></a></div>
+	<div id="manage-styles"><a id="open-manage-link" href="manage.html"></a></div>
 
 	<script src="popup.js"></script>
 

--- a/stylish-chrome/popup.js
+++ b/stylish-chrome/popup.js
@@ -66,8 +66,9 @@ function getId(event) {
 }
 
 function openLink(event) {
+	event.preventDefault();
 	chrome.tabs.create({url: event.target.href});
-	return false;
+	//return false;
 }
 
 function handleUpdate(style) {
@@ -84,4 +85,5 @@ tE("open-manage-link", "openManage");
 tE("find-styles-link", "findStylesForSite");
 
 document.getElementById("find-styles-link").addEventListener("click", openLink, false);
+document.getElementById("open-manage-link").addEventListener("click", openLink, false);
 


### PR DESCRIPTION
On Opera 15, if I edit a style from Stylish popup menu, the editor is opened in new tab and popup panel.

![stylish-opera15-editstyle](https://f.cloud.github.com/assets/42596/751428/d51066de-e4f7-11e2-9501-7808f955c52d.png)

Also, when I clicked _Managed installed styles_ from Stylish popup menu, the manage window is opened in a new window instead of tab. If I remove `target` attribute in popup.html, manage window is opened in popup panel like the above.

This PR fixes this issue.
Tested and worked on Opera 15 and Chrome 28.
