### PR TITLE
Force light theme on editor

### DIFF
--- a/content/edit.js
+++ b/content/edit.js
@@ -92,6 +92,7 @@ function init() {
 				contextMenu: "sourceeditor-context",
 				value: style.code,
 				extraKeys: extraKeys,
+				themeSwitching: false,
 				autocomplete: true
 			});
 			var sourceEditorElement = document.getElementById("sourceeditor");


### PR DESCRIPTION
This forces the editor to be light regardless the devtools theme (light or dark).
