### PR TITLE
Add @document menus to Insert menu

### DIFF
--- a/content/edit.js
+++ b/content/edit.js
@@ -17,6 +17,10 @@ var prefs = Services.prefs.getBranch("extensions.stylish.");
 
 const CSSXULNS = "@namespace url(http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul);";
 const CSSHTMLNS = "@namespace url(http://www.w3.org/1999/xhtml);";
+const MOZDOC_URL = "@-moz-document url(http://www.w3.org/) {\n\n};\n";
+const MOZDOC_URL_PREFIX = "@-moz-document url-prefix(http://www.w3.org/Style/) {\n\n};\n";
+const MOZDOC_DOMAIN = "@-moz-document domain(mozilla.org) {\n\n};\n";
+const MOZDOC_REGEXP = "@-moz-document regexp(\"https:.*\") {\n\n};\n";
 
 // Because the edit windows have different URL, we need to do this ourselves to persist the position for all edit windows.
 // Only do this if we're opened with openDialog, in which case window.opener is set

--- a/content/edit.xul
+++ b/content/edit.xul
@@ -61,6 +61,11 @@
 					<menuitem id="insert-xul" label="&xulnamespace;" accesskey="&xulnamespace.ak;" oncommand="insertCodeAtStart(CSSXULNS);"/>
 					<menuitem id="insert-chrome-folder" label="&chromefolder;" accesskey="&chromefolder.ak;" oncommand="insertChromePath()"/>
 					<menuitem id="insert-data-uri" label="&dataURI;" accesskey="&dataURI.ak;" oncommand="insertDataURI()"/>
+					<menuseparator/>
+					<menuitem id="insert-document-url" label="&docURL;" accesskey="&docURL.ak;" oncommand="insertCodeAtStart(MOZDOC_URL);"/>
+					<menuitem id="insert-document-url-prefix" label="&docUrlPrefix;" accesskey="&docUrlPrefix.ak;" oncommand="insertCodeAtStart(MOZDOC_URL_PREFIX);"/>
+					<menuitem id="insert-document-domain" label="&docDomain;" accesskey="&docDomain.ak;" oncommand="insertCodeAtStart(MOZDOC_DOMAIN);"/>
+					<menuitem id="insert-document-regexp" label="&docRegexp;" accesskey="&docRegexp.ak;" oncommand="insertCodeAtStart(MOZDOC_REGEXP);"/>
 				</menupopup>
 			</button>
 			<button id="itsalltext" label="&openintexternaleditor;" accesskey="&openintexternaleditor.ak;" itsalltext-control="internal-code" itsalltext-extension=".css" style="display: none;"/>

--- a/locale/en-US/edit.dtd
+++ b/locale/en-US/edit.dtd
@@ -4,6 +4,14 @@
 <!ENTITY chromefolder.ak "C">
 <!ENTITY dataURI "Data URI…">
 <!ENTITY dataURI.ak "D">
+<!ENTITY docURL "URL rule">
+<!ENTITY docURL.ak "U">
+<!ENTITY docUrlPrefix "URL Prefix rule">
+<!ENTITY docUrlPrefix.ak "P">
+<!ENTITY docDomain "Domain rule">
+<!ENTITY docDomain.ak "o">
+<!ENTITY docRegexp "Regexp rule">
+<!ENTITY docRegexp.ak "R">
 <!ENTITY htmlnamespace "HTML namespace as default">
 <!ENTITY htmlnamespace.ak "H">
 <!ENTITY insert "Insert">


### PR DESCRIPTION
I hope that users can easily understand and access these matching.

https://developer.mozilla.org/en-US/docs/Web/CSS/@document
https://github.com/JasonBarnabe/stylish/wiki/Valid-@-moz-document-rules

Due to a Mozilla [quirk](https://developer.mozilla.org/en-US/docs/XUL_Accesskey_FAQ_and_Policies#How_do_I_pick_an_accesskey_letter.3F), I can not gracefully handle the accesskeys for like "For Domain" or "_@_document url", so I use the "rule" of crappy as menu labels.

We can put them in a sub-menu, but it looks is not necessary, we have plenty of space, and save a operation.
