### PR TITLE
Add Tagalog as supported locales

### DIFF
--- a/chrome.manifest
+++ b/chrome.manifest
@@ -35,6 +35,7 @@ locale	stylish	ro	locale/ro/
 locale	stylish	ru	locale/ru/
 locale	stylish	sr	locale/sr/
 locale	stylish	sv-SE	locale/sv-SE/
+locale	stylish	tl	locale/tl/
 locale	stylish	tr	locale/tr/
 locale	stylish	uk	locale/uk/
 locale	stylish	vi	locale/vi/

--- a/install.rdf
+++ b/install.rdf
@@ -62,6 +62,7 @@
 		<em:translator>ThBu92 - ar</em:translator>
 		<em:translator>Alp Eren - tr</em:translator>
 		<em:translator>SW1FT - pt-PT</em:translator>
+		<em:translator>FranklinDM - tl</em:translator>
 		<em:contributor>t1470258 - icons</em:contributor>
 		<em:contributor>LouCypher - icons</em:contributor>
 		<em:contributor>s4nji - icons</em:contributor>

--- a/locale/tl/common.dtd
+++ b/locale/tl/common.dtd
@@ -1,0 +1,5 @@
+<!ENTITY editstyle "Baguhin">
+<!ENTITY editstyle.ak "B">
+<!ENTITY reportstyle "I-ulat ang estilo bilang sira">
+<!ENTITY reportedstyle "Naiulat ang estilo.">
+<!ENTITY stylish "Stylish">

--- a/locale/tl/common.properties
+++ b/locale/tl/common.properties
@@ -1,0 +1,4 @@
+deleteStyle=Sigurado ka bang nais mong alisin ang \'%S\'?
+deleteStyleTitle=Alisin itong estilo?
+deleteStyleOK=Alisin
+extensions.{46551EC9-40F0-4e47-8E18-8E5CF550CFB8}.description=Baguhin ang estilo ng web gamit ang Stylish, isang tagapamahala ng mga estilo ng user.

--- a/locale/tl/domi.dtd
+++ b/locale/tl/domi.dtd
@@ -1,0 +1,1 @@
+<!ENTITY copyselector "Kopyahin ang Selector">

--- a/locale/tl/edit.dtd
+++ b/locale/tl/edit.dtd
@@ -1,0 +1,22 @@
+<!ENTITY checkforerrors "Suriin para sa mga Error">
+<!ENTITY checkforerrors.ak "C">
+<!ENTITY chromefolder "Chrome folder path">
+<!ENTITY chromefolder.ak "C">
+<!ENTITY dataURI "Data URI…">
+<!ENTITY dataURI.ak "D">
+<!ENTITY htmlnamespace "HTML namespace as default">
+<!ENTITY htmlnamespace.ak "H">
+<!ENTITY insert "Insert">
+<!ENTITY insert.ak "I">
+<!ENTITY name "Pangalan">
+<!ENTITY name.ak "n">
+<!ENTITY openintexternaleditor "Buksan sa external editor">
+<!ENTITY openintexternaleditor.ak "O">
+<!ENTITY preview "I-preview">
+<!ENTITY preview.ak "P">
+<!ENTITY save "I-save">
+<!ENTITY save.ak "S">
+<!ENTITY wraplines "Wrap ang mga linya">
+<!ENTITY wraplines.ak "W">
+<!ENTITY xulnamespace "XUL namespace bilang default">
+<!ENTITY xulnamespace.ak "X">

--- a/locale/tl/edit.properties
+++ b/locale/tl/edit.properties
@@ -1,0 +1,5 @@
+dataURIDialogTitle=Pumili ng File na Isasama
+editstyletitle=Binabago \'%S\'
+newstyletitle=Bagong estilo
+missingcode=Maglagay ng code para sa estilong ito.
+missingname=Bigyan itong estilo ng pangalan.

--- a/locale/tl/install.dtd
+++ b/locale/tl/install.dtd
@@ -1,0 +1,6 @@
+<!ENTITY entername "Bigyan itong estilo ng pangalan:">
+<!ENTITY install "Italaga">
+<!ENTITY install.ak "I">
+<!ENTITY preview "I-preview">
+<!ENTITY preview.ak "P">
+<!ENTITY title "Italaga ang estilo ng user">

--- a/locale/tl/install.properties
+++ b/locale/tl/install.properties
@@ -1,0 +1,8 @@
+installintro=Ikaw ay sususbok na italaga ang \'%S\' sa Stylish.
+installintrononame=Ikaw ay sususbok na italaga ang isang estilo sa Stylish.
+installapp=Itong estilo ay maaring makaapekto sa %S user interface. Baka kailangang i-restart mo ang %S para umepekto itong estilo.
+installglobal=Itong estilo ay maaring makaapekto sa lahat ng mga web site.
+installsite=Itong estilo ay maaring makaapekto sa mga sumusunod na site:
+installnotype=Itong estilo ay maaring makaapekto sa mga website o sa %S user interface.
+missingname=Bigyan itong estilo ng pangalan.
+preview.tooltip=Temporarily applies this style so you can see if you like it.

--- a/locale/tl/manage.dtd
+++ b/locale/tl/manage.dtd
@@ -1,0 +1,10 @@
+<!ENTITY filter "Hanapin">
+<!ENTITY installfromurls "Mag-talaga mula sa mga URL…">
+<!ENTITY managetitle "Stylish">
+<!ENTITY nostylesstart "Bisitahin ang">
+<!ENTITY nostylesend "para sa impormasyon kung paano gamitin ang Stylish.">
+<!ENTITY sortenabled "Pinapagana">
+<!ENTITY sortname "Pangalan">
+<!ENTITY sorttype "Uri">
+<!ENTITY writenew "Magsulat ng Bagong Estilo">
+<!ENTITY writenew.ak "W">

--- a/locale/tl/manage.properties
+++ b/locale/tl/manage.properties
@@ -1,0 +1,7 @@
+appstyledescription=Nakakaapekto sa user interface.
+globalstyledescription=Nakakaapekto sa lahat.
+sitestyledescription=Nakakaapekto sa %S.
+manageaddonstitle=Mga Estilo ng User
+installfromurlsprompttitle=Mag-talaga mula sa mga URL
+installfromurlsprompt=Ilagay ang mga URL ng mga estilo ng user na gusto mong italaga. Maari ito'y mga pahina mula sa userstyles.org o mga CSS files. Ihiwalay ang mga URL gamit ang space.
+installfromurlserror=Hindi maitalaga mula sa mga sumusunod na URL: %S.

--- a/locale/tl/overlay.dtd
+++ b/locale/tl/overlay.dtd
@@ -1,0 +1,18 @@
+<!ENTITY addfile "Italaga ang file…">
+<!ENTITY addfile.ak "I">
+<!ENTITY cmd.enable.label "Paganahin">
+<!ENTITY cmd.enable.accesskey "P">
+<!ENTITY cmd.disable.label "Huwag Paganahin">
+<!ENTITY cmd.disable.accesskey "H">
+<!ENTITY cmd.uninstall.label "Alisin">
+<!ENTITY cmd.uninstall2.accesskey "A">
+<!ENTITY findstylebrowser "Maghanap ng mga estilo para sa site na ito…">
+<!ENTITY findstylebrowser.ak "M">
+<!ENTITY managestyles "Pamahalaan ang mga estilo…">
+<!ENTITY managestyles.ak "M">
+<!ENTITY turnon "Paganahin ang lahat ng mga estilo">
+<!ENTITY turnon.ak "T">
+<!ENTITY turnoff "Huwag paganahin ang lahat ng mga estilo">
+<!ENTITY turnoff.ak "T">
+<!ENTITY writestyle "Magsulat ng bagong estilo">
+<!ENTITY writestyle.ak "W">

--- a/locale/tl/overlay.properties
+++ b/locale/tl/overlay.properties
@@ -1,0 +1,14 @@
+submenuformatchingsite=Mga estilo para sa pahinang ito
+submenufornonmatchingsite=Mga estilo ng site
+submenuforglobal=Mga estilo na global
+submenuforapp=Mga estilo ng app
+tooltip=Stylish - %S site style(s), %S global style(s)
+tooltipStylesOff=Stylish - Mga estilo ay naka-off
+updatestyle=Sigurado ka bang nais mong i-update ang \'%S\'?
+updatestyleok=I-update
+updatestyletitle=I-update ang Estilo
+writeblank=Blankong estilo…
+writeblankaccesskey=B
+writefordomain=Para sa %S…
+writeforsite=Para sa URL na ito…
+writeforsiteaccesskey=U


### PR DESCRIPTION
This adds **Tagalog** as one of the supported locales for Stylish.

I tried to request this for Transifex but received no response and thought that it would be much faster if I'll just translate it locally and send a PR.